### PR TITLE
[Fix] stock: Made scheduled date required in Picking

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -246,7 +246,7 @@
                             <field name="backorder_id" readonly="1" attrs="{'invisible': [('backorder_id','=',False)]}"/>
                         </group>
                         <group>
-                            <field name="scheduled_date" attrs="{'readonly': [('id', '=', False)]}"/>
+                            <field name="scheduled_date" attrs="{'readonly': [('id', '=', False)], 'required': [('id', '!=', False)]}"/>
                             <field name="origin" placeholder="e.g. PO0032"/>
                             <field name="owner_id" groups="stock.group_tracking_owner"/>
                             <div groups="stock.group_tracking_owner" colspan="2" col="2">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:  Made scheduled date required in Picking

Current behavior before PR: Removing Scheduled Date throws traceback

```
Odoo Server Error - Validation Error

[object with reference: date_expected - date.expected]

```
Desired behavior after PR is merged: No more traceback as scheduled date is required.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
