### PR TITLE
[IMP]base: Remove create option for module

### DIFF
--- a/odoo/addons/base/module/wizard/base_module_uninstall_view.xml
+++ b/odoo/addons/base/module/wizard/base_module_uninstall_view.xml
@@ -7,7 +7,7 @@
             <field name="model">base.module.uninstall</field>
             <field name="arch" type="xml">
                 <form string="Uninstall module">
-                    <field name="module_id" groups="base.group_no_one"/>
+                    <field name="module_id" groups="base.group_no_one" options="{'no_create': True}"/>
                     <h3>The following apps will be uninstalled</h3>
                     <field name="show_all"/> Show technical modules
                     <field name="module_ids" mode="kanban">


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Uninstall wizard 

Current behavior before PR: User can create new module from Uninstall wizard 
![screenshot from 2018-07-10 23-42-28](https://user-images.githubusercontent.com/16624719/42529134-3c608dbc-849b-11e8-9e28-ea5d9b370a6e.png)
![p1](https://user-images.githubusercontent.com/16624719/42529149-48b74f2e-849b-11e8-961c-d1630d0379c1.png)

Desired behavior after PR is merged:

Now, we have removed Create option.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
