### PR TITLE
[FIX] website_crm_partner_assign: add tag if exists

### DIFF
--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -62,7 +62,8 @@ class CrmLead(models.Model):
                 partner_id = partner_dict.get(lead.id, False)
             if not partner_id:
                 tag_to_add = self.env.ref('website_crm_partner_assign.tag_portal_lead_partner_unavailable', False)
-                lead.write({'tag_ids': [(4, tag_to_add.id, False)]})
+                if tag_to_add:
+                    lead.write({'tag_ids': [(4, tag_to_add.id, False)]})
                 continue
             lead.assign_geo_localize(lead.partner_latitude, lead.partner_longitude)
             partner = self.env['res.partner'].browse(partner_id)


### PR DESCRIPTION
Steps to reproduce the bug:

- CRM--> Configuration --> Tags
- Delete the tag "No more partner available"
- CRM --> Lead --> Automatic Assignment

Bug:

It will raise Traceback
`AttributeError: 'NoneType' object has no attribute 'id'`
as Tag is not Present.


With this Commit:

It will add Tag if it exists on database.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
